### PR TITLE
1184 gsl reverse blocks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -48,3 +48,6 @@ jspm_packages
 
 #webstorm etc.
 .idea
+
+#Sublime text
+*.sublime*

--- a/src/behavior/canvas/output.js
+++ b/src/behavior/canvas/output.js
@@ -40,6 +40,7 @@ const renderBlocks = (assemblyList) => {
         rules: {
           role: dnaSlice.breed !== null ? compilerConfig.breeds[dnaSlice.breed] : null,
           hidden: dnaSlice.breed === 'B_LINKER',
+          direction: dnaSlice.destFwd ? 'forward' : 'reverse',
         },
         sequence: { initialBases: dnaSlice.dna },
       });


### PR DESCRIPTION
Adds the flag for (forward|reverse) from the GSL output.

GC: https://github.com/autodesk-lifesciences/genetic-constructor/issues/1184
Zube: https://zube.io/autodesk/genome-designer/c/1184