### PR TITLE
Build and Version Bump

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "GC-GSL-Editor",
-  "version": "2.1.8",
+  "version": "2.1.9",
   "description": "Extension to write and execute GSL (Genotype Specification Language) code and create constructs.",
   "keywords": [
     "DNA",


### PR DESCRIPTION
Weird 404 errors were seen in dev (https://github.com/autodesk-lifesciences/genetic-constructor/issues/4198#event-1458749697).  When running locally I reproduced them, but when I did a `yarn link` to use my local, rebuilt GSL, the errors went away.  So this PR is just to make sure that GC is using the latest GSL here.